### PR TITLE
KD-430: Update hook to install new devices.

### DIFF
--- a/modules/kamihaya_cms_common/kamihaya_cms_common.install
+++ b/modules/kamihaya_cms_common/kamihaya_cms_common.install
@@ -1,5 +1,7 @@
 <?php
 
+use Drupal\Core\Config\FileStorage;
+use Drupal\Core\Config\InstallStorage;
 use Drupal\Core\Site\Settings;
 
 /**
@@ -134,4 +136,54 @@ function _kamihaya_cms_common_merge_config(array $base_config, array $new_config
     }
   }
   return $base_config;
+}
+
+/**
+ * Update the list of responsive devices.
+ */
+function kamihaya_cms_common_update_10005() {
+  $entity_storage = \Drupal::entityTypeManager()->getStorage('responsive_preview_device');
+  $module_handler = \Drupal::service('extension.list.module');
+  $module_path = $module_handler->getPath('responsive_preview');
+  $config_path = $module_path . '/' . InstallStorage::CONFIG_INSTALL_DIRECTORY;
+  $file_storage = new FileStorage($config_path);
+
+  // List of old devices to delete.
+  $old_device_ids = [
+    'iphone_xs_max',
+    'galaxy_tab_s4',
+    'iphone_xs',
+    'galaxy_s9',
+  ];
+
+  // Delete old devices if they exist.
+  $devices = $entity_storage->loadMultiple($old_device_ids);
+  if ($devices) {
+    $entity_storage->delete($devices);
+    \Drupal::logger('kamihaya_cms_common')->notice('Old responsive preview devices deleted: @ids', ['@ids' => implode(', ', array_keys($devices))]);
+  }
+  else {
+    \Drupal::logger('kamihaya_cms_common')->notice('No old responsive preview devices found to delete.');
+  }
+
+  // List of new configs to import.
+  $config_ids = [
+    'responsive_preview.device.galaxy_s24',
+    'responsive_preview.device.galaxy_tab_s9',
+    'responsive_preview.device.iphone_15',
+    'responsive_preview.device.iphone_15_plus',
+  ];
+
+  foreach ($config_ids as $config_id) {
+    $data = $file_storage->read($config_id);
+
+    if ($data) {
+      $device = $entity_storage->create($data);
+      $device->save();
+      \Drupal::logger('kamihaya_cms_common')->notice('Imported device from config: @id', ['@id' => $device->id()]);
+    }
+    else {
+      \Drupal::logger('kamihaya_cms_common')->error('Config file not found or invalid for: @config_id', ['@config_id' => $config_id]);
+    }
+  }
 }


### PR DESCRIPTION
The patch applied here is not applied correctly, revist this issue later. 
https://www.drupal.org/project/responsive_preview/issues/3423333#comment-15460683

```
--------------------- ----------- --------------- ----------------------------
  Module                Update ID   Type            Description
 --------------------- ----------- --------------- ----------------------------
  kamihaya_cms_common   10005       hook_update_n   10005 - Update the list of
                                                    responsive devices.
 --------------------- ----------- --------------- ----------------------------


 ┌ Do you wish to run the specified pending updates? ───────────┐
 │ Yes                                                          │
 └──────────────────────────────────────────────────────────────┘

>  [notice] Update started: kamihaya_cms_common_update_10005
>  [notice] Old responsive preview devices deleted: iphone_xs_max, galaxy_tab_s4, iphone_xs, galaxy_s9
>  [notice] Imported device from config: galaxy_s24
>  [error]  Config file not found or invalid for: responsive_preview.device.galaxy_tab_s9
>  [error]  Config file not found or invalid for: responsive_preview.device.iphone_15
>  [notice] Imported device from config: iphone_15_plus
>  [notice] Update completed: kamihaya_cms_common_update_10005
 [success] Finished performing updates.
```